### PR TITLE
Fix compilation of `SoloMetadata`

### DIFF
--- a/source/common/config/solo_metadata.cc
+++ b/source/common/config/solo_metadata.cc
@@ -8,7 +8,7 @@ SoloMetadata::nonEmptyStringValue(const ProtobufWkt::Struct &spec,
                                   const std::string &key) {
 
   absl::optional<const Protobuf::Value *> maybe_value = value(spec, key);
-  if (!maybe_value.valid()) {
+  if (!maybe_value.has_value()) {
     return {};
   }
   const auto &value = *maybe_value.value();
@@ -27,7 +27,7 @@ SoloMetadata::nonEmptyStringValue(const ProtobufWkt::Struct &spec,
 bool SoloMetadata::boolValue(const Protobuf::Struct &spec,
                              const std::string &key) {
   absl::optional<const Protobuf::Value *> maybe_value = value(spec, key);
-  if (!maybe_value.valid()) {
+  if (!maybe_value.has_value()) {
     return {};
   }
 

--- a/test/common/config/BUILD
+++ b/test/common/config/BUILD
@@ -1,0 +1,19 @@
+licenses(["notice"])  # Apache 2
+
+load(
+    "@envoy//bazel:envoy_build_system.bzl",
+    "envoy_cc_test",
+    "envoy_package",
+)
+
+envoy_package()
+
+envoy_cc_test(
+    name = "solo_metadata_test",
+    srcs = ["solo_metadata_test.cc"],
+    repository = "@envoy",
+    deps = [
+        "//source/common/config:solo_metadata_lib",
+        "@envoy//source/common/config:metadata_lib",
+    ],
+)

--- a/test/common/config/solo_metadata_test.cc
+++ b/test/common/config/solo_metadata_test.cc
@@ -30,7 +30,7 @@ TEST(SoloMetadataTest, BoolValue) {
   Metadata::mutableMetadataValue(metadata, "filter1", "key1")
       .set_bool_value(true);
   Metadata::mutableMetadataValue(metadata, "filter2", "key2")
-      .set_bool_value(true);
+      .set_bool_value(false);
 
   const auto filter1 = metadata.filter_metadata().find("filter1")->second;
   const auto filter2 = metadata.filter_metadata().find("filter2")->second;
@@ -38,7 +38,7 @@ TEST(SoloMetadataTest, BoolValue) {
   EXPECT_TRUE(SoloMetadata::boolValue(filter1, "key1"));
   EXPECT_FALSE(SoloMetadata::boolValue(filter1, "key2"));
   EXPECT_FALSE(SoloMetadata::boolValue(filter2, "key1"));
-  EXPECT_TRUE(SoloMetadata::boolValue(filter2, "key2"));
+  EXPECT_FALSE(SoloMetadata::boolValue(filter2, "key2"));
 }
 
 } // namespace

--- a/test/common/config/solo_metadata_test.cc
+++ b/test/common/config/solo_metadata_test.cc
@@ -1,0 +1,46 @@
+#include "common/config/metadata.h"
+#include "common/config/solo_metadata.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Config {
+namespace {
+
+TEST(SoloMetadataTest, NonEmptyStringValue) {
+  envoy::api::v2::core::Metadata metadata;
+  Metadata::mutableMetadataValue(metadata, "filter1", "key1")
+      .set_string_value("");
+  Metadata::mutableMetadataValue(metadata, "filter2", "key2")
+      .set_string_value("non-empty");
+
+  const auto filter1 = metadata.filter_metadata().find("filter1")->second;
+  const auto filter2 = metadata.filter_metadata().find("filter2")->second;
+
+  EXPECT_FALSE(SoloMetadata::nonEmptyStringValue(filter1, "key1").has_value());
+  EXPECT_FALSE(SoloMetadata::nonEmptyStringValue(filter1, "key2").has_value());
+  EXPECT_FALSE(SoloMetadata::nonEmptyStringValue(filter2, "key1").has_value());
+  EXPECT_TRUE(SoloMetadata::nonEmptyStringValue(filter2, "key2").has_value());
+  EXPECT_EQ("non-empty",
+            *SoloMetadata::nonEmptyStringValue(filter2, "key2").value());
+}
+
+TEST(SoloMetadataTest, BoolValue) {
+  envoy::api::v2::core::Metadata metadata;
+  Metadata::mutableMetadataValue(metadata, "filter1", "key1")
+      .set_bool_value(true);
+  Metadata::mutableMetadataValue(metadata, "filter2", "key2")
+      .set_bool_value(true);
+
+  const auto filter1 = metadata.filter_metadata().find("filter1")->second;
+  const auto filter2 = metadata.filter_metadata().find("filter2")->second;
+
+  EXPECT_TRUE(SoloMetadata::boolValue(filter1, "key1"));
+  EXPECT_FALSE(SoloMetadata::boolValue(filter1, "key2"));
+  EXPECT_FALSE(SoloMetadata::boolValue(filter2, "key1"));
+  EXPECT_TRUE(SoloMetadata::boolValue(filter2, "key2"));
+}
+
+} // namespace
+} // namespace Config
+} // namespace Envoy


### PR DESCRIPTION
1. Fix `SoloMetadata` following the upgrade of Envoy to v1.6.0.
2. Add unit tests.