### PR TITLE
WIP - per filter config

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,24 @@
+licenses(["notice"])  # Apache 2
+
+load(
+    "@envoy//bazel:envoy_build_system.bzl",
+    "envoy_cc_binary",
+    "envoy_cc_library",
+    "envoy_cc_test",
+    "envoy_package",
+)
+
+envoy_package()
+
+load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library")
+
+api_proto_library(
+    name = "route_fault_proto",
+    srcs = ["route_fault.proto"],
+    deps = ["@envoy_api//envoy/config/filter/http/fault/v2:fault"],
+)
+
+api_proto_library(
+    name = "functional_base_proto",
+    srcs = ["functional_base.proto"],
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,6 +1,6 @@
 workspace(name="solo_envoy_common")
 
-ENVOY_SHA = "9d6b432218d8eb010bde9b7f720319378691b94a"  # April 16, 2018 (router: vhost/route/w.cluster local filter configuration)
+ENVOY_SHA = "47c63e59bb7d30f199fb20bf431ea17eace72946"  # April 19, 2018 (Add perFilerConfigObject to store pre-processed per-route-config)
 
 http_archive(
     name = "envoy",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,6 +1,6 @@
 workspace(name="solo_envoy_common")
 
-ENVOY_SHA = "d41d06eb614fd49f19422d9eed9235c320af9229"  # April 10, 2018 (gRPC/JSON transcoder: enable preserving route after headers modified)
+ENVOY_SHA = "9d6b432218d8eb010bde9b7f720319378691b94a"  # April 16, 2018 (router: vhost/route/w.cluster local filter configuration)
 
 http_archive(
     name = "envoy",

--- a/functional_base.proto
+++ b/functional_base.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package envoy.api.v2.filter.http;
+
+message FunctionalFilterRouteConfig {
+    string function_name = 1;
+}

--- a/source/common/config/solo_metadata.cc
+++ b/source/common/config/solo_metadata.cc
@@ -7,7 +7,7 @@ absl::optional<const std::string *>
 SoloMetadata::nonEmptyStringValue(const ProtobufWkt::Struct &spec,
                                   const std::string &key) {
 
-  absl::optional<const Protobuf::Value *> maybe_value = value(spec, key);
+  absl::optional<const ProtobufWkt::Value *> maybe_value = value(spec, key);
   if (!maybe_value.has_value()) {
     return {};
   }
@@ -24,9 +24,9 @@ SoloMetadata::nonEmptyStringValue(const ProtobufWkt::Struct &spec,
   return absl::optional<const std::string *>(&string_value);
 }
 
-bool SoloMetadata::boolValue(const Protobuf::Struct &spec,
+bool SoloMetadata::boolValue(const ProtobufWkt::Struct &spec,
                              const std::string &key) {
-  absl::optional<const Protobuf::Value *> maybe_value = value(spec, key);
+  absl::optional<const ProtobufWkt::Value *> maybe_value = value(spec, key);
   if (!maybe_value.has_value()) {
     return {};
   }
@@ -39,8 +39,8 @@ bool SoloMetadata::boolValue(const Protobuf::Struct &spec,
   return value.bool_value();
 }
 
-absl::optional<const Protobuf::Value *>
-SoloMetadata::value(const Protobuf::Struct &spec, const std::string &key) {
+absl::optional<const ProtobufWkt::Value *>
+SoloMetadata::value(const ProtobufWkt::Struct &spec, const std::string &key) {
   const auto &fields = spec.fields();
   const auto fields_it = fields.find(key);
   if (fields_it == fields.end()) {

--- a/source/common/config/solo_metadata.h
+++ b/source/common/config/solo_metadata.h
@@ -17,12 +17,13 @@ namespace Config {
 class SoloMetadata {
 public:
   static absl::optional<const std::string *>
-  nonEmptyStringValue(const Protobuf::Struct &spec, const std::string &key);
+  nonEmptyStringValue(const ProtobufWkt::Struct &spec, const std::string &key);
 
-  static bool boolValue(const Protobuf::Struct &spec, const std::string &key);
+  static bool boolValue(const ProtobufWkt::Struct &spec,
+                        const std::string &key);
 
-  static absl::optional<const Protobuf::Value *>
-  value(const Protobuf::Struct &spec, const std::string &key);
+  static absl::optional<const ProtobufWkt::Value *>
+  value(const ProtobufWkt::Struct &spec, const std::string &key);
 };
 
 } // namespace Config

--- a/source/common/http/BUILD
+++ b/source/common/http/BUILD
@@ -28,6 +28,7 @@ envoy_cc_library(
     hdrs = ["functional_stream_decoder_base.h"],
     repository = "@envoy",
     deps = [
+        "//:functional_base_proto_cc",
         "//include/envoy/http:metadata_accessor_interface",
         "//source/common/config:solo_well_known_names_lib",
         "//source/common/http:solo_filter_utility_lib",

--- a/source/common/http/functional_stream_decoder_base.cc
+++ b/source/common/http/functional_stream_decoder_base.cc
@@ -121,9 +121,8 @@ FunctionRetrieverMetadataAccessor::tryToGetSpec() {
   // able to do a function route or error. unless passthrough is allowed on the
   // upstream.
 
-  const envoy::api::v2::filter::http::FunctionalFilterRouteConfig
-      *filter_config =
-          per_filter_config_.getPerFilterConfig(*decoder_callbacks_);
+  const FunctionalFilterMixinRouteFilterConfig *filter_config =
+      per_filter_config_.getPerFilterConfig(*decoder_callbacks_);
   if (!filter_config) {
     // this cast should never fail, but maybe we don't have a config...
     return canPassthrough()
@@ -131,7 +130,7 @@ FunctionRetrieverMetadataAccessor::tryToGetSpec() {
                : Result::Error;
   }
 
-  function_name_ = &filter_config->function_name();
+  function_name_ = &filter_config->function_name_;
 
   return Result::Active;
 }

--- a/source/common/http/functional_stream_decoder_base.h
+++ b/source/common/http/functional_stream_decoder_base.h
@@ -14,8 +14,7 @@ class FunctionRetrieverMetadataAccessor : public MetadataAccessor {
 public:
   FunctionRetrieverMetadataAccessor(Server::Configuration::FactoryContext &ctx,
                                     const std::string &childname)
-      : cm_(ctx.clusterManager()), random_(ctx.random()),
-        childname_(childname) {}
+      : cm_(ctx.clusterManager()), childname_(childname) {}
 
   ~FunctionRetrieverMetadataAccessor();
 
@@ -39,18 +38,11 @@ public:
   }
 
 private:
-  struct FunctionWeight {
-    uint64_t weight;
-    const std::string *name;
-  };
-
   Upstream::ClusterManager &cm_;
-  Runtime::RandomGenerator &random_;
   const std::string &childname_;
 
   Upstream::ClusterInfoConstSharedPtr cluster_info_{};
-  const std::string *function_name_{};        // function name is here
-  const ProtobufWkt::Struct *cluster_spec_{}; // function spec is here
+  const std::string *function_name_{}; // function name is here
   // mutable as these are modified in a const function. it is ok as the state of
   // the object doesnt change, it is for lazy loading.
   mutable const ProtobufWkt::Struct *child_spec_{}; // childfilter is here
@@ -61,14 +53,6 @@ private:
   StreamDecoderFilterCallbacks *decoder_callbacks_{};
 
   bool canPassthrough();
-
-  absl::optional<const std::string *>
-  findSingleFunction(const ProtobufWkt::Struct &filter_metadata_struct);
-  absl::optional<const std::string *>
-  findMultileFunction(const ProtobufWkt::Struct &filter_metadata_struct);
-
-  absl::optional<FunctionWeight>
-  getFuncWeight(const ProtobufWkt::Value &function_weight_value);
 
   void tryToGetSpecFromCluster(const std::string &funcname);
   void fetchClusterInfoIfOurs();

--- a/source/common/http/functional_stream_decoder_base.h
+++ b/source/common/http/functional_stream_decoder_base.h
@@ -13,6 +13,11 @@
 namespace Envoy {
 namespace Http {
 
+struct FunctionalFilterMixinRouteFilterConfig
+    : public Router::RouteSpecificFilterConfig {
+  std::string function_name_;
+};
+
 class FunctionRetrieverMetadataAccessor : public MetadataAccessor {
 public:
   FunctionRetrieverMetadataAccessor(Server::Configuration::FactoryContext &ctx,
@@ -59,7 +64,7 @@ private:
   void tryToGetSpecFromCluster(const std::string &funcname);
   void fetchClusterInfoIfOurs();
 
-  PerFilterConfigUtil<envoy::api::v2::filter::http::FunctionalFilterRouteConfig>
+  PerFilterConfigUtil<FunctionalFilterMixinRouteFilterConfig>
       per_filter_config_;
 };
 

--- a/source/common/http/functional_stream_decoder_base.h
+++ b/source/common/http/functional_stream_decoder_base.h
@@ -4,8 +4,11 @@
 #include "envoy/server/filter_config.h"
 #include "envoy/upstream/cluster_manager.h"
 
+#include "common/http/solo_filter_utility.h"
 #include "common/http/utility.h"
 #include "common/protobuf/utility.h"
+
+#include "functional_base.pb.h"
 
 namespace Envoy {
 namespace Http {
@@ -13,8 +16,7 @@ namespace Http {
 class FunctionRetrieverMetadataAccessor : public MetadataAccessor {
 public:
   FunctionRetrieverMetadataAccessor(Server::Configuration::FactoryContext &ctx,
-                                    const std::string &childname)
-      : cm_(ctx.clusterManager()), childname_(childname) {}
+                                    const std::string &childname);
 
   ~FunctionRetrieverMetadataAccessor();
 
@@ -56,6 +58,9 @@ private:
 
   void tryToGetSpecFromCluster(const std::string &funcname);
   void fetchClusterInfoIfOurs();
+
+  PerFilterConfigUtil<envoy::api::v2::filter::http::FunctionalFilterRouteConfig>
+      per_filter_config_;
 };
 
 template <typename MixinBase> class FunctionalFilterMixin : public MixinBase {

--- a/source/common/http/solo_filter_utility.cc
+++ b/source/common/http/solo_filter_utility.cc
@@ -23,14 +23,15 @@ const std::string *SoloFilterUtility::resolveClusterName(
   return &route_entry->clusterName();
 }
 
-const Protobuf::Message *PerFilterConfigUtilBase::getPerFilterBaseConfig(
+const Router::RouteSpecificFilterConfig *
+PerFilterConfigUtilBase::getPerFilterBaseConfig(
     StreamDecoderFilterCallbacks &decoder_callbacks) {
   route_info_ = decoder_callbacks.route();
   if (!route_info_) {
     return {};
   }
 
-  const Protobuf::Message *maybe_filter_config{};
+  const Router::RouteSpecificFilterConfig *maybe_filter_config{};
 
   const Router::RouteEntry *routeEntry = route_info_->routeEntry();
   if (routeEntry) {

--- a/source/common/http/solo_filter_utility.cc
+++ b/source/common/http/solo_filter_utility.cc
@@ -33,7 +33,7 @@ const Protobuf::Message *PerFilterConfigUtilBase::getPerFilterBaseConfig(
   const Protobuf::Message *maybe_filter_config{};
 
   const Router::RouteEntry *routeEntry = route_info_->routeEntry();
-  if (!routeEntry) {
+  if (routeEntry) {
     maybe_filter_config = routeEntry->perFilterConfig(filter_name_);
   }
 

--- a/source/common/http/solo_filter_utility.cc
+++ b/source/common/http/solo_filter_utility.cc
@@ -23,5 +23,30 @@ const std::string *SoloFilterUtility::resolveClusterName(
   return &route_entry->clusterName();
 }
 
+const Protobuf::Message *PerFilterConfigUtilBase::getPerFilterBaseConfig(
+    StreamDecoderFilterCallbacks &decoder_callbacks) {
+  route_info_ = decoder_callbacks.route();
+  if (!route_info_) {
+    return {};
+  }
+
+  const Protobuf::Message *maybe_filter_config{};
+
+  const Router::RouteEntry *routeEntry = route_info_->routeEntry();
+  if (!routeEntry) {
+    maybe_filter_config = routeEntry->perFilterConfig(filter_name_);
+  }
+
+  if (!maybe_filter_config) {
+    maybe_filter_config = route_info_->perFilterConfig(filter_name_);
+  }
+
+  if (!maybe_filter_config && routeEntry) {
+    maybe_filter_config =
+        routeEntry->virtualHost().perFilterConfig(filter_name_);
+  }
+  return maybe_filter_config;
+}
+
 } // namespace Http
 } // namespace Envoy

--- a/source/common/http/solo_filter_utility.h
+++ b/source/common/http/solo_filter_utility.h
@@ -42,7 +42,7 @@ class PerFilterConfigUtilBase {
 protected:
   PerFilterConfigUtilBase(const std::string &filter_name)
       : filter_name_(filter_name) {}
-  const Protobuf::Message *
+  const Router::RouteSpecificFilterConfig *
   getPerFilterBaseConfig(StreamDecoderFilterCallbacks &decoder_callbacks);
 
 private:
@@ -50,19 +50,20 @@ private:
   Router::RouteConstSharedPtr route_info_{};
 };
 
-template <class ConfigProto>
+template <class ConfigType>
 class PerFilterConfigUtil : PerFilterConfigUtilBase {
 
-  static_assert(std::is_base_of<Protobuf::Message, ConfigProto>::value,
-                "ConfigProto must be a subclass of Protobuf::Message");
+  static_assert(
+      std::is_base_of<Router::RouteSpecificFilterConfig, ConfigType>::value,
+      "ConfigType must be a subclass of Protobuf::Message");
 
 public:
   PerFilterConfigUtil(const std::string &filter_name)
       : PerFilterConfigUtilBase(filter_name) {}
 
-  const ConfigProto *
+  const ConfigType *
   getPerFilterConfig(StreamDecoderFilterCallbacks &decoder_callbacks) {
-    return dynamic_cast<const ConfigProto *>(
+    return dynamic_cast<const ConfigType *>(
         getPerFilterBaseConfig(decoder_callbacks));
   }
 };

--- a/source/common/http/solo_filter_utility.h
+++ b/source/common/http/solo_filter_utility.h
@@ -38,5 +38,34 @@ public:
   resolveClusterName(StreamDecoderFilterCallbacks *decoder_callbacks);
 };
 
+class PerFilterConfigUtilBase {
+protected:
+  PerFilterConfigUtilBase(const std::string &filter_name)
+      : filter_name_(filter_name) {}
+  const Protobuf::Message *
+  getPerFilterBaseConfig(StreamDecoderFilterCallbacks &decoder_callbacks);
+
+private:
+  const std::string &filter_name_;
+  Router::RouteConstSharedPtr route_info_{};
+};
+
+template <class ConfigProto>
+class PerFilterConfigUtil : PerFilterConfigUtilBase {
+
+  static_assert(std::is_base_of<Protobuf::Message, ConfigProto>::value,
+                "ConfigProto must be a subclass of Protobuf::Message");
+
+public:
+  PerFilterConfigUtil(const std::string &filter_name)
+      : PerFilterConfigUtilBase(filter_name) {}
+
+  const ConfigProto *
+  getPerFilterConfig(StreamDecoderFilterCallbacks &decoder_callbacks) {
+    return dynamic_cast<const ConfigProto *>(
+        getPerFilterBaseConfig(decoder_callbacks));
+  }
+};
+
 } // namespace Http
 } // namespace Envoy

--- a/source/server/config/http/BUILD
+++ b/source/server/config/http/BUILD
@@ -33,6 +33,7 @@ envoy_cc_library(
         "@envoy//include/envoy/registry",
         "@envoy//include/envoy/server:filter_config_interface",
         "@envoy//source/common/config:filter_json_lib",
+        "@envoy//source/common/protobuf:utility_lib",
         "@envoy//source/extensions/filters/http/common:empty_http_filter_config_lib",
     ],
 )

--- a/source/server/config/http/BUILD
+++ b/source/server/config/http/BUILD
@@ -22,3 +22,17 @@ envoy_cc_library(
         "@envoy//source/common/http/filter:fault_filter_lib",
     ],
 )
+
+envoy_cc_library(
+    name = "functional_stream_decoder_lib",
+    srcs = ["functional_stream_decoder.cc"],
+    repository = "@envoy",
+    deps = [
+        "//source/common/config:solo_well_known_names_lib",
+        "//source/common/http:functional_stream_decoder_base_lib",
+        "@envoy//include/envoy/registry",
+        "@envoy//include/envoy/server:filter_config_interface",
+        "@envoy//source/common/config:filter_json_lib",
+        "@envoy//source/extensions/filters/http/common:empty_http_filter_config_lib",
+    ],
+)

--- a/source/server/config/http/functional_stream_decoder.cc
+++ b/source/server/config/http/functional_stream_decoder.cc
@@ -1,0 +1,45 @@
+#include <string>
+
+#include "envoy/registry/registry.h"
+
+#include "common/config/solo_well_known_names.h"
+
+#include "extensions/filters/http/common/empty_http_filter_config.h"
+
+#include "functional_base.pb.h"
+
+namespace Envoy {
+namespace Server {
+namespace Configuration {
+
+class FunctionBaseFilterFactory
+    : public Extensions::HttpFilters::Common::EmptyHttpFilterConfig {
+public:
+  // Server::Configuration::NamedHttpFilterConfigFactory
+  std::string name() override {
+    return Config::SoloCommonFilterNames::get().FUNCTIONAL_ROUTER;
+  }
+
+  // Server::Configuration::EmptyHttpFilterConfig
+  HttpFilterFactoryCb createFilter(const std::string &,
+                                   FactoryContext &) override {
+    return [](Http::FilterChainFactoryCallbacks &) -> void {};
+  }
+
+  virtual ProtobufTypes::MessagePtr createEmptyRouteConfigProto() {
+    return ProtobufTypes::MessagePtr{
+        new envoy::api::v2::filter::http::FunctionalFilterRouteConfig()};
+  }
+};
+
+/**
+ * Static registration for the Google Cloud Functions filter. @see
+ * RegisterFactory.
+ */
+static Registry::RegisterFactory<FunctionBaseFilterFactory,
+                                 NamedHttpFilterConfigFactory>
+    register_;
+
+} // namespace Configuration
+} // namespace Server
+} // namespace Envoy

--- a/source/server/config/http/functional_stream_decoder.cc
+++ b/source/server/config/http/functional_stream_decoder.cc
@@ -3,6 +3,8 @@
 #include "envoy/registry/registry.h"
 
 #include "common/config/solo_well_known_names.h"
+#include "common/http/functional_stream_decoder_base.h"
+#include "common/protobuf/utility.h"
 
 #include "extensions/filters/http/common/empty_http_filter_config.h"
 
@@ -26,9 +28,13 @@ public:
     return [](Http::FilterChainFactoryCallbacks &) -> void {};
   }
 
-  virtual ProtobufTypes::MessagePtr createEmptyRouteConfigProto() {
-    return ProtobufTypes::MessagePtr{
-        new envoy::api::v2::filter::http::FunctionalFilterRouteConfig()};
+  virtual Router::RouteSpecificFilterConfigConstSharedPtr
+  createRouteSpecificFilterConfig(const ProtobufWkt::Struct &source) {
+    envoy::api::v2::filter::http::FunctionalFilterRouteConfig cfg;
+    MessageUtil::jsonConvert(source, cfg);
+    auto obj = std::make_shared<Http::FunctionalFilterMixinRouteFilterConfig>();
+    obj->function_name_ = cfg.function_name();
+    return obj;
   }
 };
 

--- a/test/common/http/BUILD
+++ b/test/common/http/BUILD
@@ -29,6 +29,7 @@ envoy_cc_test(
     repository = "@envoy",
     deps = [
         "//source/common/http:route_enabled_filter_wrapper_lib",
+        "//source/server/config/http:functional_stream_decoder_lib",
         "@envoy//include/envoy/event:dispatcher_interface",
         "@envoy//source/common/http:header_map_lib",
         "@envoy//source/common/stats:stats_lib",

--- a/test/common/http/functional_stream_decoder_base_test.cc
+++ b/test/common/http/functional_stream_decoder_base_test.cc
@@ -130,7 +130,7 @@ protected:
 
     ON_CALL(filter_callbacks_.route_->route_entry_,
             perFilterConfig(
-                Config::SoloCommonMetadataFilters::get().FUNCTIONAL_ROUTER))
+                Config::SoloCommonFilterNames::get().FUNCTIONAL_ROUTER))
         .WillByDefault(Return(&route_function_));
   }
 
@@ -205,10 +205,11 @@ TEST_F(FunctionFilterTest, HaveRouteMeta) {
                             {":path", "/getsomething"}};
   filter_->decodeHeaders(headers, true);
 
-  const ProtobufWkt::Struct &receivedspec =
-      *filter_->meta_accessor_->getFunctionSpec().value();
+  ASSERT_NE(nullptr, filter_->meta_accessor_);
 
-  EXPECT_NE(nullptr, &receivedspec);
+  auto&& receivedspec = filter_->meta_accessor_->getFunctionSpec();
+
+  EXPECT_TRUE(receivedspec.has_value());
 
   EXPECT_TRUE(filter_->decodeHeadersCalled_);
   EXPECT_FALSE(filter_->decodeDataCalled_);

--- a/test/common/http/functional_stream_decoder_base_test.cc
+++ b/test/common/http/functional_stream_decoder_base_test.cc
@@ -126,11 +126,11 @@ protected:
 
   void initroutemeta() {
 
-    route_function_.set_function_name(functionname_);
+    route_function_.function_name_ = functionname_;
 
-    ON_CALL(filter_callbacks_.route_->route_entry_,
-            perFilterConfig(
-                Config::SoloCommonFilterNames::get().FUNCTIONAL_ROUTER))
+    ON_CALL(
+        filter_callbacks_.route_->route_entry_,
+        perFilterConfig(Config::SoloCommonFilterNames::get().FUNCTIONAL_ROUTER))
         .WillByDefault(Return(&route_function_));
   }
 
@@ -148,7 +148,7 @@ protected:
   ProtobufWkt::Struct *cluster_meta_function2_spec_struct_;
   envoy::api::v2::core::Metadata cluster_metadata_;
 
-  envoy::api::v2::filter::http::FunctionalFilterRouteConfig route_function_;
+  Http::FunctionalFilterMixinRouteFilterConfig route_function_;
 
   std::string childname_;
   std::string functionname_{"funcname"};
@@ -207,7 +207,7 @@ TEST_F(FunctionFilterTest, HaveRouteMeta) {
 
   ASSERT_NE(nullptr, filter_->meta_accessor_);
 
-  auto&& receivedspec = filter_->meta_accessor_->getFunctionSpec();
+  auto &&receivedspec = filter_->meta_accessor_->getFunctionSpec();
 
   EXPECT_TRUE(receivedspec.has_value());
 


### PR DESCRIPTION
This PR uses the new perFilterConfig and reduces complexity of our base filter.
don't merge yet, as I want to add more tests;

The idea is that the new filter config will have to be added, so that envoy will know the functional base filter protobuf. not sure if we have an elegant way to pull it in automatically?