### PR TITLE
use perFilterConfig in function filter base.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,18 @@
+licenses(["notice"])  # Apache 2
+
+load(
+    "@envoy//bazel:envoy_build_system.bzl",
+    "envoy_cc_binary",
+    "envoy_cc_library",
+    "envoy_cc_test",
+    "envoy_package",
+)
+
+envoy_package()
+
+load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library")
+
+api_proto_library(
+    name = "functional_base_proto",
+    srcs = ["functional_base.proto"],
+)

--- a/BUILD
+++ b/BUILD
@@ -2,9 +2,6 @@ licenses(["notice"])  # Apache 2
 
 load(
     "@envoy//bazel:envoy_build_system.bzl",
-    "envoy_cc_binary",
-    "envoy_cc_library",
-    "envoy_cc_test",
     "envoy_package",
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,6 +1,6 @@
 workspace(name="solo_envoy_common")
 
-ENVOY_SHA = "47c63e59bb7d30f199fb20bf431ea17eace72946"  # April 19, 2018 (Add perFilerConfigObject to store pre-processed per-route-config)
+ENVOY_SHA = "d8d089a6088591e681c43aabdbc671b4f8e59d0d"  # Apr 24, 2018 (http: Adding flexible remove function to HeaderMap
 
 http_archive(
     name = "envoy",

--- a/functional_base.proto
+++ b/functional_base.proto
@@ -1,0 +1,8 @@
+
+syntax = "proto3";
+
+package envoy.api.v2.filter.http;
+
+message FunctionalFilterRouteConfig {
+    string function_name = 1;
+}

--- a/source/common/http/BUILD
+++ b/source/common/http/BUILD
@@ -28,9 +28,11 @@ envoy_cc_library(
     hdrs = ["functional_stream_decoder_base.h"],
     repository = "@envoy",
     deps = [
+        "//:functional_base_proto_cc",
         "//include/envoy/http:metadata_accessor_interface",
         "//source/common/config:solo_well_known_names_lib",
         "//source/common/http:solo_filter_utility_lib",
+        "@envoy//include/envoy/registry",
         "@envoy//include/envoy/server:filter_config_interface",
         "@envoy//include/envoy/upstream:cluster_manager_interface",
         "@envoy//source/common/common:assert_lib",
@@ -38,6 +40,8 @@ envoy_cc_library(
         "@envoy//source/common/common:utility_lib",
         "@envoy//source/common/http:filter_utility_lib",
         "@envoy//source/common/http:utility_lib",
+        "@envoy//source/common/protobuf:utility_lib",
+        "@envoy//source/extensions/filters/http/common:empty_http_filter_config_lib",
     ],
 )
 

--- a/source/common/http/functional_stream_decoder_base.cc
+++ b/source/common/http/functional_stream_decoder_base.cc
@@ -90,10 +90,9 @@ FunctionRetrieverMetadataAccessor::tryToGetSpec() {
   // So now we know this this route is to a functional upstream. i.e. we must be
   // able to do a function route or error. unless passthrough is allowed on the
   // upstream.
-  const auto *filter_config =
-      SoloFilterUtility::resolvePerFilterConfig<
-          FunctionalFilterMixinRouteFilterConfig>(
-          Config::SoloCommonFilterNames::get().FUNCTIONAL_ROUTER, route_info_);
+  const auto *filter_config = SoloFilterUtility::resolvePerFilterConfig<
+      FunctionalFilterMixinRouteFilterConfig>(
+      Config::SoloCommonFilterNames::get().FUNCTIONAL_ROUTER, route_info_);
   if (!filter_config) {
     // check if we have metadata (i.e. gloo is not updated)
     // TODO(yuval-k): this will be removed in the future.
@@ -408,7 +407,7 @@ public:
  * Static registration for the Google Cloud Functions filter. @see
  * RegisterFactory.
  */
-static Envoy::Registry::RegisterFactory<
+static Registry::RegisterFactory<
     FunctionBaseFilterFactory,
     Server::Configuration::NamedHttpFilterConfigFactory>
     register_;

--- a/source/common/http/functional_stream_decoder_base.cc
+++ b/source/common/http/functional_stream_decoder_base.cc
@@ -90,13 +90,13 @@ FunctionRetrieverMetadataAccessor::tryToGetSpec() {
   // So now we know this this route is to a functional upstream. i.e. we must be
   // able to do a function route or error. unless passthrough is allowed on the
   // upstream.
-  const FunctionalFilterMixinRouteFilterConfig *filter_config =
+  const auto *filter_config =
       SoloFilterUtility::resolvePerFilterConfig<
           FunctionalFilterMixinRouteFilterConfig>(
           Config::SoloCommonFilterNames::get().FUNCTIONAL_ROUTER, route_info_);
   if (!filter_config) {
     // check if we have metadata (i.e. gloo is not updated)
-    // TODO: this will be removed in the future.
+    // TODO(yuval-k): this will be removed in the future.
     auto legacy_result = tryToGetSpecLegacy(routeEntry);
     if (legacy_result.has_value()) {
       return legacy_result.value();

--- a/source/common/http/functional_stream_decoder_base.h
+++ b/source/common/http/functional_stream_decoder_base.h
@@ -10,6 +10,11 @@
 namespace Envoy {
 namespace Http {
 
+struct FunctionalFilterMixinRouteFilterConfig
+    : public Router::RouteSpecificFilterConfig {
+  std::string function_name_;
+};
+
 class FunctionRetrieverMetadataAccessor : public MetadataAccessor {
 public:
   FunctionRetrieverMetadataAccessor(Server::Configuration::FactoryContext &ctx,
@@ -60,6 +65,8 @@ private:
 
   StreamDecoderFilterCallbacks *decoder_callbacks_{};
 
+  absl::optional<Result>
+  tryToGetSpecLegacy(const Router::RouteEntry *routeEntry);
   bool canPassthrough();
 
   absl::optional<const std::string *>

--- a/test/common/http/functional_stream_decoder_base_test.cc
+++ b/test/common/http/functional_stream_decoder_base_test.cc
@@ -81,7 +81,7 @@ protected:
     filter_->setDecoderFilterCallbacks(filter_callbacks_);
   }
 
-  void initclustermeta(bool passthrough = false) {
+  void initClusterMeta(bool passthrough = false) {
 
     // TODO use const
     ProtobufWkt::Struct &functionsstruct =
@@ -131,7 +131,7 @@ protected:
         &((*route_metadata_.mutable_filter_metadata())[childname_]);
   }
 
-  void initrouteperfilter() {
+  void initRoutePerFilter() {
     route_function_.function_name_ = functionname_;
 
     ON_CALL(
@@ -140,7 +140,7 @@ protected:
         .WillByDefault(Return(&route_function_));
   }
 
-  void initroutemeta() {
+  void initRouteMeta() {
 
     ProtobufWkt::Value functionvalue;
     functionvalue.set_string_value(functionname_);
@@ -165,7 +165,7 @@ protected:
             routefunctionmeta;
   }
 
-  void initroutemetamultiple() {
+  void initRouteMetamultiple() {
 
     ProtobufWkt::Struct multifunction;
     auto clustername = filter_callbacks_.route_->route_entry_.cluster_name_;
@@ -249,8 +249,8 @@ TEST_F(FunctionFilterTest, NothingConfigured) {
 }
 
 TEST_F(FunctionFilterTest, HappyPathPerFilter) {
-  initclustermeta();
-  initrouteperfilter();
+  initClusterMeta();
+  initRoutePerFilter();
 
   TestHeaderMapImpl headers{{":method", "GET"},
                             {":authority", "www.solo.io"},
@@ -262,8 +262,8 @@ TEST_F(FunctionFilterTest, HappyPathPerFilter) {
 }
 
 TEST_F(FunctionFilterTest, HaveRouteMeta) {
-  initclustermeta();
-  initroutemeta();
+  initClusterMeta();
+  initRouteMeta();
   auto clustername = filter_callbacks_.route_->route_entry_.cluster_name_;
   EXPECT_CALL(factory_context_.cluster_manager_, get(clustername))
       .Times(AtLeast(1));
@@ -284,8 +284,8 @@ TEST_F(FunctionFilterTest, HaveRouteMeta) {
 }
 
 TEST_F(FunctionFilterTest, MetaNoCopy) {
-  initclustermeta();
-  initroutemeta();
+  initClusterMeta();
+  initRouteMeta();
   initchildroutemeta();
 
   TestHeaderMapImpl headers{{":method", "GET"},
@@ -308,7 +308,7 @@ TEST_F(FunctionFilterTest, MetaNoCopy) {
 }
 
 TEST_F(FunctionFilterTest, MissingRouteMetaPassThrough) {
-  initclustermeta(true);
+  initClusterMeta(true);
 
   TestHeaderMapImpl headers{{":method", "GET"},
                             {":authority", "www.solo.io"},
@@ -319,7 +319,7 @@ TEST_F(FunctionFilterTest, MissingRouteMetaPassThrough) {
 }
 
 TEST_F(FunctionFilterTest, MissingRouteMeta) {
-  initclustermeta();
+  initClusterMeta();
 
   std::string status;
 
@@ -342,8 +342,8 @@ TEST_F(FunctionFilterTest, MissingRouteMeta) {
 }
 
 TEST_F(FunctionFilterTest, MissingChildRouteMeta) {
-  initclustermeta();
-  initroutemeta();
+  initClusterMeta();
+  initRouteMeta();
 
   TestHeaderMapImpl headers{{":method", "GET"},
                             {":authority", "www.solo.io"},
@@ -354,8 +354,8 @@ TEST_F(FunctionFilterTest, MissingChildRouteMeta) {
 }
 
 TEST_F(FunctionFilterTest, FoundChildRouteMeta) {
-  initclustermeta();
-  initroutemeta();
+  initClusterMeta();
+  initRouteMeta();
   initchildroutemeta();
 
   TestHeaderMapImpl headers{{":method", "GET"},
@@ -367,8 +367,8 @@ TEST_F(FunctionFilterTest, FoundChildRouteMeta) {
 }
 
 TEST_F(FunctionFilterTest, FindMultiFunctions) {
-  initclustermeta();
-  initroutemetamultiple();
+  initClusterMeta();
+  initRouteMetamultiple();
   EXPECT_CALL(factory_context_.random_, random()).WillOnce(Return(0));
 
   TestHeaderMapImpl headers{{":method", "GET"},
@@ -381,8 +381,8 @@ TEST_F(FunctionFilterTest, FindMultiFunctions) {
 }
 
 TEST_F(FunctionFilterTest, FindMultiFunctions2) {
-  initclustermeta();
-  initroutemetamultiple();
+  initClusterMeta();
+  initRouteMetamultiple();
 
   EXPECT_CALL(factory_context_.random_, random()).WillOnce(Return(6));
 


### PR DESCRIPTION
this is still backwards compatible with older method for now.
this moves the function routing back to envoy where it belongs